### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -8,7 +8,7 @@ use Fcntl qw(:seek);
 BEGIN {
     unshift @INC, "$Bin/../lib";
     for my $mod ('PPI', 'PPI::Transform::Doxygen') {
-        use_ok($mod, "load $mod") or BAIL_OUT("cannot load $mod");
+        use_ok($mod) or BAIL_OUT("cannot load $mod");
     }
 };
 

--- a/t/02_signatures.t
+++ b/t/02_signatures.t
@@ -9,7 +9,7 @@ use Fcntl qw(:seek);
 BEGIN {
     unshift @INC, "$Bin/../lib";
     for my $mod ('PPI', 'PPI::Transform::Doxygen') {
-        use_ok($mod, "load $mod") or BAIL_OUT("cannot load $mod");
+        use_ok($mod) or BAIL_OUT("cannot load $mod");
     }
 };
 


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.